### PR TITLE
Feat/iss 3/command change thread icon

### DIFF
--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require("discord.js");
 
-const MAPPED_COMMANDS = {
+const MAPPED_STATUS_COMMANDS = {
   'pr-no-merge': '🚫',
   'pr-sos': '🆘',
   'pr-draft': '🚧',
@@ -14,7 +14,7 @@ const MAPPED_COMMANDS = {
   'pr-merged-task-created': '✅🛫📋'
 };
 
-const COMMAND_KEYS = Object.keys(MAPPED_COMMANDS);
+const COMMAND_KEYS = Object.keys(MAPPED_STATUS_COMMANDS);
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -40,22 +40,22 @@ module.exports = {
     ),
   async execute(interaction) {
     try {
-      
+
       const { options, channel } = interaction;
-  
+
       if (!channel.isThread()) return await interaction.reply("Sorry, this is not a thread!");
-  
+
       const status = options.getString('status');
-      const newStatus = MAPPED_COMMANDS[status];
-  
+      const newStatus = MAPPED_STATUS_COMMANDS[status];
+
       if (!newStatus) {
         return await interaction.reply("Invalid status command.");
       }
-  
-      const oldStatus = COMMAND_KEYS.find(command => channel.name.startsWith(MAPPED_COMMANDS[command]));
-      const regex = new RegExp(`(${MAPPED_COMMANDS[oldStatus]})`, 'g');
+
+      const oldStatus = COMMAND_KEYS.find(command => channel.name.startsWith(MAPPED_STATUS_COMMANDS[command]));
+      const regex = new RegExp(`(${MAPPED_STATUS_COMMANDS[oldStatus]})`, 'g');
       const channelNameWithStatus = oldStatus ? channel.name.replace(regex, newStatus) : `${newStatus} ${channel.name}`;
-  
+
       await channel.setName(channelNameWithStatus);
       await interaction.reply(`Status updated to ${channelNameWithStatus}`);
     } catch (error) {

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -25,17 +25,7 @@ module.exports = {
         .setDescription('status command')
         .setRequired(true)
         .addChoices(
-          { name: '/pr-no-merge', value: 'pr-no-merge' },
-          { name: '/pr-sos', value: 'pr-sos' },
-          { name: '/pr-draft', value: 'pr-draft' },
-          { name: '/pr-reviewing', value: 'pr-reviewing' },
-          { name: '/pr-request-changes', value: 'pr-request-changes' },
-          { name: '/pr-request-review', value: 'pr-request-review' },
-          { name: '/pr-working-in-fixes', value: 'pr-working-in-fixes' },
-          { name: '/pr-approved', value: 'pr-approved' },
-          { name: '/pr-merged', value: 'pr-merged' },
-          { name: '/pr-merged-need-tasks', value: 'pr-merged-need-tasks' },
-          { name: '/pr-merged-task-created', value: 'pr-merged-task-created' }
+          COMMAND_KEYS.map(command => ({ name: `/${command}`, value: command }))
         )
     ),
   async execute(interaction) {

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -36,18 +36,19 @@ module.exports = {
       if (!channel.isThread()) return await interaction.reply({ content: "Sorry, this is not a thread!", ephemeral: true });
 
       const status = options.getString('status');
+      const channelName = channel.name;
       const newStatus = MAPPED_STATUS_COMMANDS[status];
 
       if (!newStatus) {
         return await interaction.reply("Invalid status command.");
       }
 
-      const oldStatus = COMMAND_KEYS.find(command => channel.name.startsWith(MAPPED_STATUS_COMMANDS[command]));
+      const oldStatus = COMMAND_KEYS.find(command => channelName.split(' ')[0] === MAPPED_STATUS_COMMANDS[command]);
       const regex = new RegExp(`(${MAPPED_STATUS_COMMANDS[oldStatus]})`, 'g');
-      const channelNameWithStatus = oldStatus ? channel.name.replace(regex, newStatus) : `${newStatus} ${channel.name}`;
+      const channelNameWithStatus = oldStatus ? channelName.replace(regex, newStatus) : `${newStatus} ${channelName}`;
 
       await channel.setName(channelNameWithStatus);
-      await interaction.reply(`Status updated to ${channelNameWithStatus}`);
+      await interaction.reply(`Status updated to ${status}`);
     } catch (error) {
       await interaction.reply("An error occurred while updating the status.");
     }

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -25,7 +25,7 @@ module.exports = {
         .setDescription('status command')
         .setRequired(true)
         .addChoices(
-          COMMAND_KEYS.map(command => ({ name: command, value: command }))
+          COMMAND_KEYS.map(command => ({ name: command.replaceAll('pr-', '').replaceAll('-', ' '), value: command }))
         )
     ),
   async execute(interaction) {
@@ -33,7 +33,7 @@ module.exports = {
 
       const { options, channel } = interaction;
 
-      if (!channel.isThread()) return await interaction.reply("Sorry, this is not a thread!");
+      if (!channel.isThread()) return await interaction.reply({ content: "Sorry, this is not a thread!", ephemeral: true });
 
       const status = options.getString('status');
       const newStatus = MAPPED_STATUS_COMMANDS[status];

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -48,7 +48,7 @@ module.exports = {
       const channelNameWithStatus = oldStatus ? channelName.replace(regex, newStatus) : `${newStatus} ${channelName}`;
 
       await channel.setName(channelNameWithStatus);
-      await interaction.reply(`Status updated to ${status}`);
+      await interaction.reply(`Status updated to ${status.replaceAll('-', ' ')}`);
     } catch (error) {
       await interaction.reply("An error occurred while updating the status.");
     }

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -1,0 +1,65 @@
+const { SlashCommandBuilder } = require("discord.js");
+
+const MAPPED_COMMANDS = {
+  'pr-no-merge': '🚫',
+  'pr-sos': '🆘',
+  'pr-draft': '🚧',
+  'pr-reviewing': '👀',
+  'pr-request-changes': '🔁',
+  'pr-request-review': '❗',
+  'pr-working-in-fixes': '🧑‍🔧',
+  'pr-approved': '✅',
+  'pr-merged': '✅🛫',
+  'pr-merged-need-tasks': '✅🛫📝',
+  'pr-merged-task-created': '✅🛫📋'
+};
+
+const COMMAND_KEYS = Object.keys(MAPPED_COMMANDS);
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('changestatus')
+    .setDescription('Change the status of the thread')
+    .addStringOption(option =>
+      option.setName('status')
+        .setDescription('status command')
+        .setRequired(true)
+        .addChoices(
+          { name: '/pr-no-merge', value: 'pr-no-merge' },
+          { name: '/pr-sos', value: 'pr-sos' },
+          { name: '/pr-draft', value: 'pr-draft' },
+          { name: '/pr-reviewing', value: 'pr-reviewing' },
+          { name: '/pr-request-changes', value: 'pr-request-changes' },
+          { name: '/pr-request-review', value: 'pr-request-review' },
+          { name: '/pr-working-in-fixes', value: 'pr-working-in-fixes' },
+          { name: '/pr-approved', value: 'pr-approved' },
+          { name: '/pr-merged', value: 'pr-merged' },
+          { name: '/pr-merged-need-tasks', value: 'pr-merged-need-tasks' },
+          { name: '/pr-merged-task-created', value: 'pr-merged-task-created' }
+        )
+    ),
+  async execute(interaction) {
+    try {
+      
+      const { options, channel } = interaction;
+  
+      if (!channel.isThread()) return await interaction.reply("Sorry, this is not a thread!");
+  
+      const status = options.getString('status');
+      const newStatus = MAPPED_COMMANDS[status];
+  
+      if (!newStatus) {
+        return await interaction.reply("Invalid status command.");
+      }
+  
+      const oldStatus = COMMAND_KEYS.find(command => channel.name.startsWith(MAPPED_COMMANDS[command]));
+      const regex = new RegExp(`(${MAPPED_COMMANDS[oldStatus]})`, 'g');
+      const channelNameWithStatus = oldStatus ? channel.name.replace(regex, newStatus) : `${newStatus} ${channel.name}`;
+  
+      await channel.setName(channelNameWithStatus);
+      await interaction.reply(`Status updated to ${channelNameWithStatus}`);
+    } catch (error) {
+      await interaction.reply("An error occurred while updating the status.");
+    }
+  },
+};

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -18,14 +18,14 @@ const COMMAND_KEYS = Object.keys(MAPPED_STATUS_COMMANDS);
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName('changestatus')
+    .setName('change-status')
     .setDescription('Change the status of the thread')
     .addStringOption(option =>
       option.setName('status')
         .setDescription('status command')
         .setRequired(true)
         .addChoices(
-          COMMAND_KEYS.map(command => ({ name: `/${command}`, value: command }))
+          COMMAND_KEYS.map(command => ({ name: command, value: command }))
         )
     ),
   async execute(interaction) {


### PR DESCRIPTION
### Description

In this pr was added a new command to handle the status of threads using specific command param at the beginning of the thread name. These commands represent the current status of the thread. For example, using ✅ task indicates that the task is already approved. This PR introduces a new function to change the thread icon and adds commands for the statuses:

- Was added a new command to manage the state of a pr/thread
- Was added icons to manage the current status of the thread (pr).

Fixes:
 - #3 

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.

### Screenshots

- Base thread
> ![image](https://github.com/user-attachments/assets/9c14ae17-3732-4037-8f7e-5bfd7ec31742)

>![image](https://github.com/user-attachments/assets/ada114c8-79ef-45d3-9def-77f3537caaa4)

- status Updated

>![image](https://github.com/user-attachments/assets/aa88019b-3ff5-417b-b2ef-e7e311d60f7d)

>![image](https://github.com/user-attachments/assets/3a9da8e8-aeb8-4e36-ba09-276d103d9655)


