### PR TITLE
refator: iss 21/deploy commands and events

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -21,7 +21,6 @@ module.exports = (client) => {
       if ('data' in command && 'execute' in command) {
         commands.push(command.data.toJSON());
         client.commands.set(command.data.name, command);
-
       } else {
         console.log(
           `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -3,49 +3,53 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { DISCORD_CONFIG } = require('./config');
 
-const commands = [];
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
-const token = DISCORD_CONFIG.discordToken;
-const clientId = DISCORD_CONFIG.discordClientId;
-const guildId = DISCORD_CONFIG.discordGuildId;
+module.exports = (client) => {
+  const commands = [];
+  const foldersPath = path.join(__dirname, 'commands');
+  const commandFolders = fs.readdirSync(foldersPath);
+  const token = DISCORD_CONFIG.discordToken;
+  const clientId = DISCORD_CONFIG.discordClientId;
+  const guildId = DISCORD_CONFIG.discordGuildId;
 
-for (const folder of commandFolders) {
-  const commandsPath = path.join(foldersPath, folder);
-  const commandFiles = fs
-    .readdirSync(commandsPath)
-    .filter((file) => file.endsWith('.js'));
-  for (const file of commandFiles) {
-    const command = require(path.join(commandsPath, file));
-    if ('data' in command && 'execute' in command) {
-      commands.push(command.data.toJSON());
-    } else {
-      console.log(
-        `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`
-      );
+  for (const folder of commandFolders) {
+    const commandsPath = path.join(foldersPath, folder);
+    const commandFiles = fs
+      .readdirSync(commandsPath)
+      .filter((file) => file.endsWith('.js'));
+    for (const file of commandFiles) {
+      const command = require(path.join(commandsPath, file));
+      if ('data' in command && 'execute' in command) {
+        commands.push(command.data.toJSON());
+        client.commands.set(command.data.name, command);
+
+      } else {
+        console.log(
+          `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`
+        );
+      }
     }
   }
+
+  const rest = new REST().setToken(token);
+
+  const init = async () => {
+    try {
+      console.log(
+        `Started refreshing ${commands.length} application (/) commands.`
+      );
+
+      const data = await rest.put(
+        Routes.applicationGuildCommands(clientId, guildId),
+        { body: commands }
+      );
+
+      console.log(
+        `Successfully reloaded ${data.length} application (/) commands.`
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  init();
 }
-
-const rest = new REST().setToken(token);
-
-const init = async () => {
-  try {
-    console.log(
-      `Started refreshing ${commands.length} application (/) commands.`
-    );
-
-    const data = await rest.put(
-      Routes.applicationGuildCommands(clientId, guildId),
-      { body: commands }
-    );
-
-    console.log(
-      `Successfully reloaded ${data.length} application (/) commands.`
-    );
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-init();

--- a/src/deploy-events.js
+++ b/src/deploy-events.js
@@ -1,0 +1,20 @@
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = (client) => {
+
+  const eventsPath = path.join(__dirname, 'events');
+  const eventFiles = fs
+    .readdirSync(eventsPath)
+    .filter((file) => file.endsWith('.js'));
+
+  for (const file of eventFiles) {
+    const event = require(path.join(eventsPath, file));
+    if (event.once) {
+      client.once(event.name, event.execute);
+    } else {
+      client.on(event.name, event.execute);
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 require('dotenv').config();
-const fs = require('node:fs');
-const path = require('node:path');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
-require('./deploy-commands');
 const { DISCORD_CONFIG, cronTimes } = require('./config');
 const { scheduleMessages } = require('./cron/schedule-messages');
+const deployEvents = require('./deploy-events');
+const deployCommands = require('./deploy-commands');
 
 const client = new Client({
   intents: [
@@ -17,40 +16,10 @@ const client = new Client({
 });
 
 client.commands = new Collection();
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
 const token = DISCORD_CONFIG.discordToken;
 
-for (const folder of commandFolders) {
-  const commandsPath = path.join(foldersPath, folder);
-  const commandFiles = fs
-    .readdirSync(commandsPath)
-    .filter((file) => file.endsWith('.js'));
-  for (const file of commandFiles) {
-    const command = require(path.join(commandsPath, file));
-    if ('data' in command && 'execute' in command) {
-      client.commands.set(command.data.name, command);
-    } else {
-      console.log(
-        `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`
-      );
-    }
-  }
-}
-
-const eventsPath = path.join(__dirname, 'events');
-const eventFiles = fs
-  .readdirSync(eventsPath)
-  .filter((file) => file.endsWith('.js'));
-
-for (const file of eventFiles) {
-  const event = require(path.join(eventsPath, file));
-  if (event.once) {
-    client.once(event.name, event.execute);
-  } else {
-    client.on(event.name, event.execute);
-  }
-}
+deployCommands(client);
+deployEvents(client);
 
 scheduleMessages(client, cronTimes.messageTimes);
 


### PR DESCRIPTION
### Description

This PR refactors the logic for registering and deploying commands and events for the Discord bot. The main changes include moving the command registration logic into a dedicated deploy-commands.js file and ensuring that commands are registered and deployed in a sequential manner. Additionally, the event handling logic has been modularized for better maintainability.

- Moved the logic for reading and registering commands from index.js to `deploy-commands.js`.
- Ensured that commands are added to the client collection before being deployed to Discord.
- Moved the logic for reading and registering events from index.js to `deploy-events.js`.

Fixes:
 - #21 

#### Type of change

- [x] Refactor feature (non-breaking change which improve functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] The logic for deploy commands and events are separated in files instead of be on index
 - [x] All work as before
 - [x] The bot is not doing the same work twice 