### PR TITLE
feat: include author in query for User's PRs query points command

### DIFF
--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -60,17 +60,17 @@ module.exports = {
       ? channels.map((channel) => `in:${channel}`).join(' ')
       : '';
 
-    const openedPRs = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} Author: @${escapedUserId}`;
+    const openedPRs = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} Author: ${escapedUserId}`;
     const taskCompletedQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.taskCompletedTagId}> ${escapedUserId}`;
     const addPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.addPointTagId}> ${escapedUserId}`;
     const boostedPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.boostedPointTagId}> ${escapedUserId}`;
 
     await interaction.reply({
       content: `Here are your search queries:
-        \n\n**PRs opened:**\n\`\`\`${openedPRs}\`\`\`
-        \n\n**Tasks completed:**\n\`\`\`${taskCompletedQuery}\`\`\`
-        \n\n**Points obtained:**\n\`\`\`${addPointQuery}\`\`\`
-        \n\n**Boosted Points obtained:**\n\`\`\`${boostedPointQuery}\`\`\``,
+        \n**PRs opened:**\n\`\`\`${openedPRs}\`\`\`
+        \n**Tasks completed:**\n\`\`\`${taskCompletedQuery}\`\`\`
+        \n**Points obtained:**\n\`\`\`${addPointQuery}\`\`\`
+        \n**Boosted Points obtained:**\n\`\`\`${boostedPointQuery}\`\`\``,
       ephemeral: true,
     });
   },

--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -60,12 +60,17 @@ module.exports = {
       ? channels.map((channel) => `in:${channel}`).join(' ')
       : '';
 
+    const openedPRs = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} Author: @${escapedUserId}`;
     const taskCompletedQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.taskCompletedTagId}> ${escapedUserId}`;
     const addPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.addPointTagId}> ${escapedUserId}`;
     const boostedPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.boostedPointTagId}> ${escapedUserId}`;
 
     await interaction.reply({
-      content: `Here are your search queries:\n\n**Tasks completed:**\n\`\`\`${taskCompletedQuery}\`\`\`\n\n**Points obtained:**\n\`\`\`${addPointQuery}\`\`\`\n\n**Boosted Points obtained:**\n\`\`\`${boostedPointQuery}\`\`\``,
+      content: `Here are your search queries:
+        \n\n**PRs opened:**\n\`\`\`${openedPRs}\`\`\`
+        \n\n**Tasks completed:**\n\`\`\`${taskCompletedQuery}\`\`\`
+        \n\n**Points obtained:**\n\`\`\`${addPointQuery}\`\`\`
+        \n\n**Boosted Points obtained:**\n\`\`\`${boostedPointQuery}\`\`\``,
       ephemeral: true,
     });
   },


### PR DESCRIPTION
### Description

This PR addresses an issue with the query points command that returns the queries for checking user points for the year, month, etc. The command initially provided three types of queries: one for Add Point, another for Add Boosted Points, and another for Task Completed. However, it missed the query Author: **`@user`** which is essential for retrieving the PRs opened by the user. This feat ensures that the command now includes this crucial query, improving its functionality and user experience.

Fixes:
 - #46 

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.

### How to Test It:
- Run the query points Command.
- Verify that the command returns four queries: Add Point, Add Boosted Points, Task Completed, and Author: @user.
- Validate that the results are accurate and match the user's open PRs.

### Screenshots

>![image](https://github.com/user-attachments/assets/d47e2ffb-7ae1-47ed-bd19-bcd99a6ef9a2)
