### PR TITLE
fix: set day to zero to take the selected month

### DIFF
--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -44,12 +44,12 @@ module.exports = {
       ? channelsInput.split(',').map((channel) => channel.trim())
       : [];
 
-    const targetStartDate = new Date(year, month - 1, 1);
+    const targetStartDate = new Date(year, month - 1, 0);
     const targetEndDate = new Date(year, month, 1);
 
     const startDateStr = `${targetStartDate.getFullYear()}-${String(
       targetStartDate.getMonth() + 1
-    ).padStart(2, '0')}-01`;
+    ).padStart(2, '0')}-${String(targetStartDate.getDate())}`;
     const endDateStr = `${targetEndDate.getFullYear()}-${String(
       targetEndDate.getMonth() + 1
     ).padStart(2, '0')}-01`;


### PR DESCRIPTION
### Description

This PR addresses an issue with the date-range filter for the /my-query-points command, which was not working properly. The filter was returning incorrect date ranges when selecting specific months. The main change ensures that the `after` filter now correctly captures the entire month, providing accurate results for point queries.

Fixes:
 - #51  

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.

### How to Test It:
- Run the query points Command.
- Verify that the command returns the correct date for whole month
- Validate that the results are accurate and match the user's open PRs.

### Screenshots

>![image](https://github.com/user-attachments/assets/505a8d17-014c-4be8-a507-cd47dc2a7709)
