### PR TITLE
fix: plus one when is in first month

### DIFF
--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -38,7 +38,7 @@ module.exports = {
     const year =
       interaction.options.getInteger('year') || currentDate.getFullYear();
     const month =
-      interaction.options.getInteger('month') || currentDate.getMonth() || 12;
+      interaction.options.getInteger('month') || currentDate.getMonth() + 1;
     const user = interaction.options.getUser('user') || interaction.user;
 
     const channelsInput = interaction.options.getString('channels');


### PR DESCRIPTION
### Description

This PR addresses a bug in the `/my-query-points` command where specifying only the user returns points for the incorrect previous month. Specifically, if the current month is January, the command should return the points for December of the previous year, not the current year.

Fixes:
 - #72 

#### Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Checklist:
- [x] Doesn't break the current code.
- [x] Passes linters and tests, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.

### How to Test It:
1. Go to the Discord server.
2. Use the `/my-query-points` command.
3. Select a User and leave the other fields blank.
4. Ensure the response returns points for the correct date range:
- If in January, the points should be from the last day of November of the previous year to the first day of January of the current year (e.g., last day of November 2024 to the first day of January 2025).
5. Verify that the command returns the correct points for other months as well.
6. Run the application to ensure overall functionality and that no new issues have been introduced.

### Screenshots

>![image](https://github.com/user-attachments/assets/7c38ade0-7481-4535-b628-a105dd5e0e8e)
