### PR TITLE
 feat: /send-message command to include ephemeral confirmation

### DIFF
--- a/src/handlers/modal-submit.js
+++ b/src/handlers/modal-submit.js
@@ -1,5 +1,6 @@
 const { formatPRMessage } = require('../utils/pr-formatter');
 const { formatSendMessage } = require('../utils/send-message-formatter');
+const { translateLanguage } = require('../languages/index');
 
 async function handleModalSubmit(interaction) {
   await interaction.deferReply({ ephemeral: true });
@@ -24,7 +25,7 @@ async function handleModalSubmit(interaction) {
 
       if (!channel) {
         await interaction.editReply({
-          content: '❌ The channel you are trying to access was not found.',
+          content: translateLanguage('prTemplate.modal.channelNotFound'),
           ephemeral: true,
         });
         return;
@@ -33,8 +34,7 @@ async function handleModalSubmit(interaction) {
       const permissions = channel.permissionsFor(interaction.client.user);
       if (!permissions.has('SendMessages')) {
         await interaction.editReply({
-          content:
-            "❌ I don't have permission to send messages in that channel.",
+          content: translateLanguage('prTemplate.modal.noPermissions'),
           ephemeral: true,
         });
         return;
@@ -42,17 +42,20 @@ async function handleModalSubmit(interaction) {
 
       await channel.send(formattedMessage);
       await interaction.editReply({
-        content: `✅ PR review request has been posted in ${channel}!`,
+        content: translateLanguage('prTemplate.modal.postSuccess', {
+          channel: channel.toString(),
+        }),
         ephemeral: true,
       });
     } catch (error) {
       console.error('Error sending PR message:', error);
       await interaction.editReply({
-        content: '❌ Failed to post PR review request. Please try again.',
+        content: translateLanguage('prTemplate.modal.postError'),
         ephemeral: true,
       });
     }
   }
+
   if (interaction.customId.startsWith('send-message-modal-')) {
     const result = interaction.customId.replace('send-message-modal-', '');
     const [channelId, userName] = result.split('-');
@@ -71,7 +74,7 @@ async function handleModalSubmit(interaction) {
 
       if (!channel) {
         await interaction.editReply({
-          content: '❌ The channel you are trying to access was not found.',
+          content: translateLanguage('sendMessage.modal.channelNotFound'),
           ephemeral: true,
         });
         return;
@@ -80,8 +83,7 @@ async function handleModalSubmit(interaction) {
       const permissions = channel.permissionsFor(interaction.client.user);
       if (!permissions.has('SendMessages')) {
         await interaction.editReply({
-          content:
-            "❌ I don't have permission to send messages in that channel.",
+          content: translateLanguage('sendMessage.modal.noPermissions'),
           ephemeral: true,
         });
         return;
@@ -89,13 +91,15 @@ async function handleModalSubmit(interaction) {
 
       await channel.send(formattedMessage);
       await interaction.editReply({
-        content: `✅ PR review request has been posted in ${channel}!`,
+        content: translateLanguage('sendMessage.modal.postSuccess', {
+          channel: channel.toString(),
+        }),
         ephemeral: true,
       });
     } catch (error) {
-      console.error('Error sending PR message:', error);
+      console.error('Error sending announcement:', error);
       await interaction.editReply({
-        content: '❌ Failed to post PR review request. Please try again.',
+        content: translateLanguage('sendMessage.modal.postError'),
         ephemeral: true,
       });
     }

--- a/src/handlers/modal-submit.js
+++ b/src/handlers/modal-submit.js
@@ -1,6 +1,6 @@
 const { formatPRMessage } = require('../utils/pr-formatter');
 const { formatSendMessage } = require('../utils/send-message-formatter');
-const { translateLanguage } = require('../../languages/index');
+const { translateLanguage } = require('../languages/index');
 
 async function handleModalSubmit(interaction) {
   await interaction.deferReply({ ephemeral: true });

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -28,7 +28,11 @@
       "urlLabel": "GitHub PR URL",
       "titleLabel": "PR Title",
       "overviewLabel": "Overview",
-      "howToTestLabel": "How to Test"
+      "howToTestLabel": "How to Test",
+      "channelNotFound": "❌ The channel you are trying to access was not found.",
+      "noPermissions": "❌ I don't have permission to send messages in that channel.",
+      "postSuccess": "✅ PR review request has been posted in {{channel}}!",
+      "postError": "❌ Failed to post PR review request. Please try again."
     }
   },
   "requestPoint": {
@@ -54,7 +58,11 @@
     "modal": {
       "modalTitle": "Send Message Request",
       "titleLabel": "Message Title",
-      "descriptionLabel": "Message Description"
+      "descriptionLabel": "Message Description",
+      "channelNotFound": "❌ The channel you are trying to access was not found.",
+      "noPermissions": "❌ I don't have permission to send messages in that channel.",
+      "postSuccess": "✅ The announcement has been successfully posted in {{channel}}!",
+      "postError": "❌ Failed to post the announcement. Please try again."
     }
   },
   "server": {

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -29,7 +29,11 @@
       "titleLabel": "Título del PR",
       "overviewLabel": "Descripción general",
       "howToTestLabel": "Cómo probar",
-      "required": "Este campo es obligatorio"
+      "required": "Este campo es obligatorio",
+      "channelNotFound": "❌ No se encontró el canal al que intentas acceder.",
+      "noPermissions": "❌ No tengo permiso para enviar mensajes en ese canal.",
+      "postSuccess": "✅ La solicitud de revisión de PR se ha publicado en {{channel}}.",
+      "postError": "❌ No se pudo publicar la solicitud de revisión de PR. Inténtalo de nuevo."
     }
   },
   "requestPoint": {
@@ -55,7 +59,11 @@
     "modal": {
       "modalTitle": "Solicitud de Envío de Mensaje",
       "titleLabel": "Título del Mensaje",
-      "descriptionLabel": "Descripción del Mensaje"
+      "descriptionLabel": "Descripción del Mensaje",
+      "channelNotFound": "❌ No se encontró el canal al que intentas acceder.",
+      "noPermissions": "❌ No tengo permiso para enviar mensajes en ese canal.",
+      "postSuccess": "✅ El anuncio se ha publicado correctamente en {{channel}}.",
+      "postError": "❌ No se pudo publicar el anuncio. Inténtalo de nuevo."
     }
   },
   "server": {


### PR DESCRIPTION
-    Sends an ephemeral confirmation to the user posting the announcement.
-    Ensures better feedback and error handling for permissions or channel issues.