### PR TITLE
feat: add reminder for pr request review Status in Bot Commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,5 @@ TIME_BETWEEN_AI_AUTOMATIC_INTERACTION='0 10,15 * * 1-5'
 AI_AUTOMATIC_INTERACTION_CHANNEL=1270770663048613983
 AI_AUTOMATIC_INTERACTION_PROMPTS='Generate a programming quiz question with four options and highlight the correct answer,Create a curiosity about the history of programming or software development,Write an inspirational message for developers facing challenges,Create a question about Git commands with four options and provide the correct answer,Generate a JavaScript code snippet quiz with unexpected behavior and multiple-choice answers,Share a fun fact about a popular programming language,Write a motivational quote for junior developers learning to code'
 
+# CRON Job Schedule
+CRON_SCHEDULE_REVIEW='0 7 * * 1,5'

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, ChannelType } = require('discord.js');
 const { translateLanguage } = require('../../languages/index');
-const { MAPPED_STATUS_COMMANDS } = require('../../config'); // Mantenemos esta importación
+const { MAPPED_STATUS_COMMANDS } = require('../../config');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -25,7 +25,7 @@ module.exports = {
         return;
       }
 
-      const statusText = MAPPED_STATUS_COMMANDS['pr-request-review']; // Usar el mapeo
+      const statusText = MAPPED_STATUS_COMMANDS['pr-request-review'];
       if (!statusText) {
         throw new Error('Mapped status for pr-request-review not found.');
       }

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -1,0 +1,71 @@
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const { translateLanguage } = require('../../languages/index');
+const { MAPPED_STATUS_COMMANDS } = require('../../config');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('check-review')
+    .setDescription(translateLanguage('checkReview.description'))
+    .addChannelOption((option) =>
+      option
+        .setName('channel')
+        .setDescription(translateLanguage('checkReview.channelOption'))
+        .addChannelTypes(ChannelType.GuildText)
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    try {
+      const channel = interaction.options.getChannel('channel');
+      if (!channel) {
+        await interaction.reply({
+          content: translateLanguage('checkReview.noChannels'),
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const now = Date.now();
+      const threshold = 24 * 60 * 60 * 1000;
+      const reminders = [];
+      const statusEmoji = MAPPED_STATUS_COMMANDS['pr-request-review'];
+
+      const messages = await channel.messages.fetch({ limit: 50 });
+
+      const pendingReviews = messages.filter(
+        (msg) =>
+          msg.content.includes(statusEmoji) &&
+          msg.createdTimestamp < now - threshold
+      );
+
+      if (pendingReviews.size > 0) {
+        for (const msg of pendingReviews.values()) {
+          reminders.push(
+            `🔔 **Reminder**: The message from [${msg.author.tag}] with status \`pr-request-review\` has not been reviewed:\n${msg.url}`
+          );
+        }
+
+        await interaction.reply({
+          content: reminders.join('\n\n'),
+          ephemeral: true,
+        });
+      } else {
+        const channelName = channel.name;
+        const noPRMessage = translateLanguage(
+          'checkReview.noPendingReviews'
+        ).replace('{{channelName}}', channelName);
+
+        await interaction.reply({
+          content: noPRMessage,
+          ephemeral: true,
+        });
+      }
+    } catch (error) {
+      console.error(`Error in check-review command: ${error}`);
+      await interaction.reply({
+        content: translateLanguage('checkReview.error'),
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, ChannelType } = require('discord.js');
 const { translateLanguage } = require('../../languages/index');
-const { MAPPED_STATUS_COMMANDS } = require('../../config');
+const { MAPPED_STATUS_COMMANDS } = require('../../config'); // Mantenemos esta importación
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -25,23 +25,26 @@ module.exports = {
         return;
       }
 
-      const now = Date.now();
-      const threshold = 24 * 60 * 60 * 1000;
+      const statusText = MAPPED_STATUS_COMMANDS['pr-request-review']; // Usar el mapeo
+      if (!statusText) {
+        throw new Error('Mapped status for pr-request-review not found.');
+      }
+
       const reminders = [];
-      const statusEmoji = MAPPED_STATUS_COMMANDS['pr-request-review'];
 
-      const messages = await channel.messages.fetch({ limit: 50 });
+      // Fetch active threads in the channel
+      const threads = await channel.threads.fetchActive();
 
-      const pendingReviews = messages.filter(
-        (msg) =>
-          msg.content.includes(statusEmoji) &&
-          msg.createdTimestamp < now - threshold
+      // Filter threads where the title contains the desired status text
+      const pendingReviews = threads.threads.filter((thread) =>
+        thread.name.includes(statusText)
       );
 
       if (pendingReviews.size > 0) {
-        for (const msg of pendingReviews.values()) {
+        // Create reminders for each pending review thread
+        for (const thread of pendingReviews.values()) {
           reminders.push(
-            `🔔 **Reminder**: The message from [${msg.author.tag}] with status \`pr-request-review\` has not been reviewed:\n${msg.url}`
+            `🔔 **Reminder**: The thread [${thread.name}] has not been reviewed:\n${thread.url}`
           );
         }
 

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -1,6 +1,10 @@
 const { SlashCommandBuilder, ChannelType } = require('discord.js');
 const { translateLanguage } = require('../../languages/index');
-const { MAPPED_STATUS_COMMANDS } = require('../../config');
+// const { MAPPED_STATUS_COMMANDS } = require('../../config');
+const {
+  getMappedStatusText,
+  STATUS_KEY,
+} = require('../../cron/schedule-code-review');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -25,7 +29,7 @@ module.exports = {
         return;
       }
 
-      const statusText = MAPPED_STATUS_COMMANDS['pr-request-review'];
+      const statusText = getMappedStatusText(STATUS_KEY);
       if (!statusText) {
         throw new Error('Mapped status for pr-request-review not found.');
       }
@@ -44,7 +48,9 @@ module.exports = {
         // Create reminders for each pending review thread
         for (const thread of pendingReviews.values()) {
           reminders.push(
-            `🔔 **Reminder**: The thread [${thread.name}] has not been reviewed:\n${thread.url}`
+            translateLanguage('checkReview.threadNotReviewed')
+              .replace('{{threadName}}', thread.name)
+              .replace('{{threadUrl}}', thread.url)
           );
         }
 

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, ChannelType } = require('discord.js');
 const { translateLanguage } = require('../../languages/index');
-// const { MAPPED_STATUS_COMMANDS } = require('../../config');
 const {
   getMappedStatusText,
   STATUS_KEY,

--- a/src/config.js
+++ b/src/config.js
@@ -38,7 +38,7 @@ const QA_MENTION = {
   discordQAChannelName: process.env.DISCORD_QA_CHANNEL_ID,
 };
 
-const CRON_SHEDULE_REVIEW = {
+const CRON_SCHEDULE_REVIEW = {
   scheduleReview: process.env.CRON_SCHEDULE_REVIEW || '0 7 * * 1,5',
   timeZone: process.env.TIME_ZONE || 'America/Bogota',
 };
@@ -127,5 +127,5 @@ module.exports = {
   PR_TEMPLATE,
   SCHEDULE_CALENDAR,
   GEMINI_INTEGRATION,
-  CRON_SHEDULE_REVIEW,
+  CRON_SCHEDULE_REVIEW,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,10 @@ const QA_MENTION = {
   discordQAChannelName: process.env.DISCORD_QA_CHANNEL_ID,
 };
 
+const CRON_SHECDULE_REVIEW = {
+  scheduleReview: process.env.CRON_EXPRESSION_REVIEW_MENTION,
+};
+
 const REQUEST_POINT = {
   discordAdminPointRequestChannel: process.env.ADMIN_POINT_REQUEST_CHANNEL,
   discordAdminTagId: process.env.ADMINISTRATOR_TAG_ID,
@@ -122,4 +126,5 @@ module.exports = {
   PR_TEMPLATE,
   SCHEDULE_CALENDAR,
   GEMINI_INTEGRATION,
+  CRON_SHECDULE_REVIEW,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ const path = require('path');
 const DISCORD_SERVER = {
   discordToken: process.env.DISCORD_TOKEN,
   discordClientId: process.env.DISCORD_CLIENT_ID,
-  discordGuildId: process.env.DISCORD_GUILD_ID || '1270770662222463026',
+  discordGuildId: process.env.DISCORD_GUILD_ID,
   botLanguage: process.env.DISCORD_LANGUAGE || 'en',
 };
 
@@ -38,8 +38,9 @@ const QA_MENTION = {
   discordQAChannelName: process.env.DISCORD_QA_CHANNEL_ID,
 };
 
-const CRON_SHECDULE_REVIEW = {
+const CRON_SHEDULE_REVIEW = {
   scheduleReview: process.env.CRON_EXPRESSION_REVIEW_MENTION,
+  timeZone: process.env.TIME_ZONE || 'America/Bogota',
 };
 
 const REQUEST_POINT = {
@@ -126,5 +127,5 @@ module.exports = {
   PR_TEMPLATE,
   SCHEDULE_CALENDAR,
   GEMINI_INTEGRATION,
-  CRON_SHECDULE_REVIEW,
+  CRON_SHEDULE_REVIEW,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -39,7 +39,7 @@ const QA_MENTION = {
 };
 
 const CRON_SHEDULE_REVIEW = {
-  scheduleReview: process.env.CRON_EXPRESSION_REVIEW_MENTION,
+  scheduleReview: process.env.CRON_SCHEDULE_REVIEW || '0 7 * * 1,5',
   timeZone: process.env.TIME_ZONE || 'America/Bogota',
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ const path = require('path');
 const DISCORD_SERVER = {
   discordToken: process.env.DISCORD_TOKEN,
   discordClientId: process.env.DISCORD_CLIENT_ID,
-  discordGuildId: process.env.DISCORD_GUILD_ID,
+  discordGuildId: process.env.DISCORD_GUILD_ID || '1270770662222463026',
   botLanguage: process.env.DISCORD_LANGUAGE || 'en',
 };
 

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -4,7 +4,7 @@ const { translateLanguage } = require('../languages/index');
 const {
   MAPPED_STATUS_COMMANDS,
   DISCORD_SERVER,
-  CRON_SHECDULE_REVIEW,
+  CRON_SHEDULE_REVIEW,
 } = require('../config');
 
 /**
@@ -77,7 +77,7 @@ const checkThreadsForReview = async (client, statusText) => {
  * @param {Client} client - The Discord.js client instance.
  * @param {string} timeZone - The timezone for the cron job.
  */
-const scheduleReviewCheck = (client, timeZone) => {
+const scheduleReviewCheck = (client) => {
   const statusText = MAPPED_STATUS_COMMANDS['pr-request-review'];
   if (!statusText) {
     console.error('Mapped status for pr-request-review not found.');
@@ -85,13 +85,13 @@ const scheduleReviewCheck = (client, timeZone) => {
   }
 
   new CronJob(
-    CRON_SHECDULE_REVIEW.scheduleReview,
+    CRON_SHEDULE_REVIEW.scheduleReview,
     () => {
       checkThreadsForReview(client, statusText);
     },
     null,
     true,
-    timeZone
+    CRON_SHEDULE_REVIEW.timeZone
   );
 };
 

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -1,6 +1,7 @@
 const { CronJob } = require('cron');
 const { ChannelType } = require('discord.js');
 const { translateLanguage } = require('../languages/index');
+const saveErrorLog = require('./utils/log-error');
 const {
   MAPPED_STATUS_COMMANDS,
   DISCORD_SERVER,
@@ -8,6 +9,10 @@ const {
 } = require('../config');
 
 const STATUS_KEY = 'pr-request-review';
+
+function handleCriticalError(error) {
+  saveErrorLog(error);
+}
 
 /**
  * Retrieves the mapped status text for the given key.
@@ -81,16 +86,12 @@ const checkThreadsForReview = async (client, statusText) => {
             )
           );
         }
-      } catch (channelError) {
-        console.error(
-          `Error processing channel ${channel.name}: ${channelError.message}`
-        );
+      } catch (error) {
+        console.error(handleCriticalError(error));
       }
     }
   } catch (error) {
-    console.error(
-      `Error fetching guild or processing threads: ${error.message}`
-    );
+    console.error(handleCriticalError(error));
   }
 };
 

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -75,7 +75,7 @@ const checkThreadsForReview = async (client, statusText) => {
  * Schedules a cron job to run `checkThreadsForReview` at specified intervals.
  *
  * @param {Client} client - The Discord.js client instance.
- * @param {string} timeZone - The timezone for the cron job.
+ *
  */
 const scheduleReviewCheck = (client) => {
   const statusText = MAPPED_STATUS_COMMANDS['pr-request-review'];

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -83,11 +83,11 @@ const checkThreadsForReview = async (client, statusText) => {
           );
         }
       } catch (error) {
-        console.error(saveErrorLog(error));
+        saveErrorLog(error);
       }
     }
   } catch (error) {
-    console.error(saveErrorLog(error));
+    saveErrorLog(error);
   }
 };
 

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -1,7 +1,11 @@
 const { CronJob } = require('cron');
 const { ChannelType } = require('discord.js');
 const { translateLanguage } = require('../languages/index');
-const { MAPPED_STATUS_COMMANDS, DISCORD_SERVER } = require('../config');
+const {
+  MAPPED_STATUS_COMMANDS,
+  DISCORD_SERVER,
+  CRON_SHECDULE_REVIEW,
+} = require('../config');
 
 /**
  * Checks threads for a specific status and sends reminders in all text channels.
@@ -81,7 +85,7 @@ const scheduleReviewCheck = (client, timeZone) => {
   }
 
   new CronJob(
-    '0 7 * * 1,5',
+    CRON_SHECDULE_REVIEW.scheduleReview,
     () => {
       checkThreadsForReview(client, statusText);
     },

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -59,9 +59,15 @@ const checkThreadsForReview = async (client, statusText) => {
         );
 
         if (pendingReviews.size > 0) {
-          let messageContent = `🔔 **Pending Threads in ${channel.name}**:\n\n`;
+          let messageContent = `${translateLanguage(
+            'checkReview.pendingThreads'
+          ).replace('{{channelName}}', channel.name)}\n\n`;
           for (const thread of pendingReviews.values()) {
-            messageContent += `The thread [${thread.name}] has not been reviewed:\n${thread.url}\n`;
+            messageContent += `${translateLanguage(
+              'checkReview.threadNotReviewed'
+            )
+              .replace('{{threadName}}', thread.name)
+              .replace('{{threadUrl}}', thread.url)}\n`;
           }
 
           await channel.send({
@@ -121,4 +127,4 @@ const scheduleReviewCheck = (client) => {
   }
 };
 
-module.exports = { scheduleReviewCheck };
+module.exports = { scheduleReviewCheck, getMappedStatusText, STATUS_KEY };

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -10,10 +10,6 @@ const {
 
 const STATUS_KEY = 'pr-request-review';
 
-function handleCriticalError(error) {
-  saveErrorLog(error);
-}
-
 /**
  * Retrieves the mapped status text for the given key.
  *
@@ -87,11 +83,11 @@ const checkThreadsForReview = async (client, statusText) => {
           );
         }
       } catch (error) {
-        console.error(handleCriticalError(error));
+        console.error(saveErrorLog(error));
       }
     }
   } catch (error) {
-    console.error(handleCriticalError(error));
+    console.error(saveErrorLog(error));
   }
 };
 

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -1,0 +1,104 @@
+const { CronJob } = require('cron');
+const { ChannelType } = require('discord.js');
+const { translateLanguage } = require('../languages/index');
+const { MAPPED_STATUS_COMMANDS, DISCORD_SERVER } = require('../config');
+
+/**
+ * Checks threads for a specific status and sends reminders in all text channels.
+ *
+ * @param {Client} client - The Discord.js client instance.
+ * @param {string} statusText - The status to look for in thread titles.
+ */
+const checkThreadsForReview = async (client, statusText) => {
+  try {
+    // Log the guild ID to check if it's correct
+    console.log(`Fetching guild with ID: ${DISCORD_SERVER.discordGuildId}`);
+
+    // Fetch the guild
+    const guild = await client.guilds.fetch(DISCORD_SERVER.discordGuildId);
+
+    if (!guild) {
+      console.error(
+        `Guild with ID ${DISCORD_SERVER.discordGuildId} not found.`
+      );
+      return;
+    }
+
+    console.log('Guild found:', guild.name);
+
+    // Fetch all channels in the guild
+    const channels = await guild.channels.fetch();
+    const textChannels = channels.filter(
+      (channel) => channel.type === ChannelType.GuildText
+    );
+
+    if (textChannels.size === 0) {
+      console.error('No text channels found.');
+      return;
+    }
+
+    for (const channel of textChannels.values()) {
+      try {
+        // Fetch active threads in the channel
+        const threads = await channel.threads.fetchActive();
+        const pendingReviews = threads.threads.filter((thread) =>
+          thread.name.includes(statusText)
+        );
+
+        if (pendingReviews.size > 0) {
+          for (const thread of pendingReviews.values()) {
+            await thread.send(
+              `🔔 **Reminder**: This thread has been marked with \`${statusText}\` and needs attention.`
+            );
+          }
+          console.log(translateLanguage('checkReview.remindersSent'));
+        } else {
+          console.log(
+            translateLanguage('checkReview.noPendingReviews').replace(
+              '{{channelName}}',
+              channel.name
+            )
+          );
+        }
+      } catch (channelError) {
+        console.error(
+          `Error processing channel ${channel.name}: ${channelError.message}`
+        );
+      }
+    }
+  } catch (error) {
+    console.error(
+      `Error fetching guild or processing threads: ${error.message}`
+    );
+  }
+};
+
+/**
+ * Schedules a cron job to run `checkThreadsForReview` at specified intervals.
+ *
+ * @param {Client} client - The Discord.js client instance.
+ * @param {string} timeZone - The timezone for the cron job.
+ */
+const scheduleReviewCheck = (client, timeZone) => {
+  const statusText = MAPPED_STATUS_COMMANDS['pr-request-review'];
+  if (!statusText) {
+    console.error('Mapped status for pr-request-review not found.');
+    return;
+  }
+
+  // Schedule a cron job to run every minute
+  new CronJob(
+    '* * * * *', // Cron expression for every minute
+    () => {
+      console.log('Running check-review cron job...');
+      checkThreadsForReview(client, statusText);
+    },
+    null,
+    true,
+    timeZone
+  ).start();
+
+  console.log(`Scheduled check-review for every minute (${timeZone})`);
+};
+
+module.exports = { scheduleReviewCheck };

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -4,7 +4,7 @@ const { translateLanguage } = require('../languages/index');
 const {
   MAPPED_STATUS_COMMANDS,
   DISCORD_SERVER,
-  CRON_SHEDULE_REVIEW,
+  CRON_SCHEDULE_REVIEW,
 } = require('../config');
 
 const STATUS_KEY = 'pr-request-review';
@@ -99,7 +99,7 @@ const scheduleReviewCheck = (client) => {
     return;
   }
 
-  const schedule = CRON_SHEDULE_REVIEW.scheduleReview;
+  const schedule = CRON_SCHEDULE_REVIEW.scheduleReview;
 
   if (typeof schedule !== 'string' || !schedule.trim()) {
     console.error('Invalid or missing cron schedule in configuration.');
@@ -114,7 +114,7 @@ const scheduleReviewCheck = (client) => {
       },
       null,
       true,
-      CRON_SHEDULE_REVIEW.timeZone
+      CRON_SCHEDULE_REVIEW.timeZone
     );
   } catch (error) {
     console.error('Failed to create CronJob:', error.message);

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const { scheduleIaContentLogging } = require('../src/cron/schedule-gemini');
 const saveErrorLog = require('./utils/log-error');
 const convertCronToText = require('./utils/cron-to-text-parser');
 const { processMarkdownFiles } = require('./cron/utils/read-markdown-messages');
+const { scheduleReviewCheck } = require('./cron/schedule-code-review');
 
 async function startClientBot(client) {
   client.commands = new Collection();
@@ -40,6 +41,16 @@ async function startClientBot(client) {
     );
     console.log(convertCronToText(SCHEDULE_CALENDAR.scheduledCalendarInterval));
   }
+
+  const cronExpression = '* * * * *'; // Cron para ejecutarse de lunes a viernes a las 7:00 AM
+  const timeZone = 'America/Bogota'; // Hora de Colombia
+
+  // Llama a la función que ejecutará el check-review a la hora programada
+  scheduleReviewCheck({
+    client,
+    cronExpression,
+    timeZone,
+  });
 
   await client.login(token);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const {
   SCHEDULE_MESSAGES,
   SCHEDULE_CALENDAR,
   GEMINI_INTEGRATION,
-  TIME_ZONES,
+  CRON_SHEDULE_REVIEW,
 } = require('./config');
 const deployEvents = require('./deploy-events');
 const deployCommands = require('./deploy-commands');
@@ -43,7 +43,7 @@ async function startClientBot(client) {
     console.log(convertCronToText(SCHEDULE_CALENDAR.scheduledCalendarInterval));
   }
 
-  const timeZone = TIME_ZONES.timeZone;
+  const timeZone = CRON_SHEDULE_REVIEW.timeZone;
   scheduleReviewCheck(client, timeZone);
 
   await client.login(token);

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const {
   SCHEDULE_MESSAGES,
   SCHEDULE_CALENDAR,
   GEMINI_INTEGRATION,
-  CRON_SHEDULE_REVIEW,
+  CRON_SCHEDULE_REVIEW,
 } = require('./config');
 const deployEvents = require('./deploy-events');
 const deployCommands = require('./deploy-commands');
@@ -43,7 +43,7 @@ async function startClientBot(client) {
     console.log(convertCronToText(SCHEDULE_CALENDAR.scheduledCalendarInterval));
   }
 
-  const timeZone = CRON_SHEDULE_REVIEW.timeZone;
+  const timeZone = CRON_SCHEDULE_REVIEW.timeZone;
   scheduleReviewCheck(client, timeZone);
 
   await client.login(token);

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const {
   SCHEDULE_MESSAGES,
   SCHEDULE_CALENDAR,
   GEMINI_INTEGRATION,
+  TIME_ZONES,
 } = require('./config');
 const deployEvents = require('./deploy-events');
 const deployCommands = require('./deploy-commands');
@@ -42,7 +43,7 @@ async function startClientBot(client) {
     console.log(convertCronToText(SCHEDULE_CALENDAR.scheduledCalendarInterval));
   }
 
-  const timeZone = 'America/Bogota';
+  const timeZone = TIME_ZONES.timeZone;
   scheduleReviewCheck(client, timeZone);
 
   await client.login(token);

--- a/src/index.js
+++ b/src/index.js
@@ -42,15 +42,8 @@ async function startClientBot(client) {
     console.log(convertCronToText(SCHEDULE_CALENDAR.scheduledCalendarInterval));
   }
 
-  const cronExpression = '* * * * *'; // Cron para ejecutarse de lunes a viernes a las 7:00 AM
-  const timeZone = 'America/Bogota'; // Hora de Colombia
-
-  // Llama a la función que ejecutará el check-review a la hora programada
-  scheduleReviewCheck({
-    client,
-    cronExpression,
-    timeZone,
-  });
+  const timeZone = 'America/Bogota';
+  scheduleReviewCheck(client, timeZone);
 
   await client.login(token);
 }
@@ -65,8 +58,6 @@ const client = new Client({
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
-    GatewayIntentBits.GuildMessagePolls,
-    GatewayIntentBits.DirectMessagePolls,
   ],
 });
 client.commands = new Collection();
@@ -75,7 +66,7 @@ process.on('uncaughtException', (error) => {
   handleCriticalError(error);
 });
 
-process.on('unhandledRejection', async (reason, promise) => {
+process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise);
   handleCriticalError(reason);
 });

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -111,8 +111,9 @@
     "channelOption": "Select the channel to check for PRs",
     "invalidChannel": "The selected channel is not valid. Please select a text channel or thread.",
     "noPendingReviews": "There are no PRs in 'request-review' status that need reminders in channel {{channelName}}.",
-    "reminder": "🔔 Reminder: The PR in thread {{threadName}} has been in 'request-review' status for too long. Please provide your review.",
+    "pendingThreads": "🔔 **Pending Threads in {{channelName}} :",
     "remindersSent": "Sent reminders for {count} PR(s) requiring review in channel {{channelName}}.",
+    "threadNotReviewed": "The thread {{threadName}} has not been reviewed:\n {{threadUrl}}",
     "error": "An error occurred while checking for PRs. Please try again later."
   }
 }

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -104,5 +104,15 @@
   "messageSchedules": {
     "errorMissingParameters": "Error: Missing one or more required parameters (client, channel, message, datetime, or timeZone).",
     "errorChannelNotFound": "Channel not found or client not ready."
+  },
+
+  "checkReview": {
+    "description": "Check for PRs that need code reviews",
+    "channelOption": "Select the channel to check for PRs",
+    "invalidChannel": "The selected channel is not valid. Please select a text channel or thread.",
+    "noPendingReviews": "There are no PRs in 'request-review' status that need reminders in channel {{channelName}}.",
+    "reminder": "🔔 Reminder: The PR in thread {{threadName}} has been in 'request-review' status for too long. Please provide your review.",
+    "remindersSent": "Sent reminders for {count} PR(s) requiring review in channel {{channelName}}.",
+    "error": "An error occurred while checking for PRs. Please try again later."
   }
 }

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -108,12 +108,13 @@
   },
 
   "checkReview": {
-    "description": "Verificar PRs que necesitan revisión de código",
-    "channelOption": "Selecciona el canal para verificar PRs",
+    "description": "Revisar los PR que necesitan revisiones de código",
+    "channelOption": "Selecciona el canal para verificar los PR",
     "invalidChannel": "El canal seleccionado no es válido. Por favor, selecciona un canal de texto o hilo.",
-    "noPendingReviews": "No hay PRs en estado 'request-review' que necesiten recordatorios en el canal {{channelName}}",
-    "reminder": "🔔 Recordatorio: El PR en el hilo {{threadName}} lleva demasiado tiempo en estado 'request-review'. Por favor, realiza tu revisión.",
-    "remindersSent": "Se enviaron recordatorios para {count} PR(s) que necesitan revisión en el canal {{channelName}}",
-    "error": "Ocurrió un error al verificar los PRs. Por favor, intenta nuevamente más tarde."
+    "noPendingReviews": "No hay PR en estado 'request-review' que necesiten recordatorios en el canal {{channelName}}.",
+    "pendingThreads": "🔔 **Hilos pendientes en {{channelName}}:**",
+    "remindersSent": "Se enviaron recordatorios para {count} PR(s) que requieren revisión en el canal {{channelName}}.",
+    "threadNotReviewed": "El hilo {{threadName}} no ha sido revisado:\n {{threadUrl}}",
+    "error": "Ocurrió un error al verificar los PR. Por favor, intenta nuevamente más tarde."
   }
 }

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -105,5 +105,15 @@
   "messageSchedules": {
     "errorMissingParameters": "Error: Falta uno o más parámetros requeridos (client, channel, message, datetime, o timeZone).",
     "errorChannelNotFound": "Canal no encontrado o cliente no listo."
+  },
+
+  "checkReview": {
+    "description": "Verificar PRs que necesitan revisión de código",
+    "channelOption": "Selecciona el canal para verificar PRs",
+    "invalidChannel": "El canal seleccionado no es válido. Por favor, selecciona un canal de texto o hilo.",
+    "noPendingReviews": "No hay PRs en estado 'request-review' que necesiten recordatorios en el canal {{channelName}}",
+    "reminder": "🔔 Recordatorio: El PR en el hilo {{threadName}} lleva demasiado tiempo en estado 'request-review'. Por favor, realiza tu revisión.",
+    "remindersSent": "Se enviaron recordatorios para {count} PR(s) que necesitan revisión en el canal {{channelName}}",
+    "error": "Ocurrió un error al verificar los PRs. Por favor, intenta nuevamente más tarde."
   }
 }


### PR DESCRIPTION
This PR introduces a feature in the check-review command to send a reminder when a PR with the status pr-request-review has not been reviewed within a specific time threshold (24 hours by default).

Changes include:

- Added logic to check messages for the pr-request-review status in the check-review command.
- Sends reminders to code reviewers if any PR is pending for review.
- Updated language translations to include English and Spanish versions of the reminder message.
- Files Updated:

- check-review.js: Added logic to filter messages with the pr-request-review status and send reminders.
- config.js: Used the mapped status pr-request-review emoji (❗).
- translateLanguage.js: Added new keys for reminder messages in both English and Spanish.