### PR TITLE
refactor: improve command flow with user selector

### DIFF
--- a/src/commands/utility/assignTaskForum.js
+++ b/src/commands/utility/assignTaskForum.js
@@ -46,13 +46,14 @@ module.exports = {
     .setName('assign')
     .setDescription(translateLanguage('assignTaskForum.description'))
     .setDescriptionLocalizations(keyTranslations('assignTaskForum.description'))
-    .addStringOption((option) =>
+    .addUserOption((option) =>
       option
         .setName('user')
         .setDescription(translateLanguage('assignTaskForum.userOption'))
         .setDescriptionLocalizations(
           keyTranslations('assignTaskForum.userOption')
         )
+        .setRequired(false)
     ),
   async execute(interaction) {
     try {
@@ -65,7 +66,7 @@ module.exports = {
 
       const forum = channel.parent;
       const assignedUser = (
-        options.getString('user') || user.username
+        options.getUser('user').username || user.username
       ).toLowerCase();
       const { userTag, reply } = getUserTagForAssignment(
         forum,

--- a/src/commands/utility/assignTaskForum.js
+++ b/src/commands/utility/assignTaskForum.js
@@ -66,7 +66,7 @@ module.exports = {
 
       const forum = channel.parent;
       const assignedUser = (
-        options.getUser('user').username || user.username
+        options.getUser('user')?.username || user.username
       ).toLowerCase();
       const { userTag, reply } = getUserTagForAssignment(
         forum,


### PR DESCRIPTION
### Description
Improved and added a new user selector to assign task from a forum related to posted tasks. The `/assign` command allows users to assign a user (or themselves) to a task within the `tareas-disponibles` forum.  When executed, the command removes the "Available" tag and applies the tag corresponding to the user executing the command.

* **User Selection List:**
    * Added a param of `addUserOption` type  to get available users as an option when using the `/assign` command.
    * This list allows users to easily select themselves for task assignment.

### Fixes
 - #85 

### Type of change

- [x] Refactor feature (non-breaking change which refactor functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] Run project without errors.
 - [x] Run new command without errors.
 - [x] refactored feature is working fine.

### How to test
1. Run the project
2. Run the `/assign` command and select an option in `user` param
3. Check the bot response
### Screenshot
>![image](https://github.com/user-attachments/assets/58054208-32ed-4c3f-b4d8-2ed5428f26f0)
>![image](https://github.com/user-attachments/assets/d85d0ba1-871a-44af-b446-a9dd14883b45)
>![image](https://github.com/user-attachments/assets/9e2edb8b-48b1-4921-a210-a327bbad6575)

