### PR TITLE
fix: add default section to show simple descriptions

### DIFF
--- a/src/events/listenPullRequestOpenMessage.js
+++ b/src/events/listenPullRequestOpenMessage.js
@@ -9,23 +9,32 @@ const headers = {
   'Content-Type': 'application/json',
 };
 
-function capitalizeText(text) {
-  if (!text) {
+function toCamelCase(str) {
+  if (!str) {
     return '';
   }
-  return text
-    .toLowerCase()
-    .split(' ')
-    .map((word) => {
-      return word.charAt(0).toUpperCase() + word.slice(1);
-    })
-    .join(' ');
-}
 
-function toCamelCase(str) {
   return str
     .toLowerCase()
     .replace(/[^a-zA-Z0-9]+(.)/g, (_, char) => char.toUpperCase());
+}
+
+function camelCaseToNormal(camelCaseString) {
+  const words = camelCaseString
+    .replace(/([A-Z])/g, ' $1')
+    .trim()
+    .split(' ');
+  return words
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function extractSectionTitle(line) {
+  const match = line.trim().match(/^#+\s*(.*)/);
+  if (match && match[1]) {
+    return match[1].trim().toLowerCase();
+  }
+  return null;
 }
 
 function cleanStringArray(arr) {
@@ -91,35 +100,29 @@ function extractPRMetadata(description = '') {
 
   let lastSectionKey = 'description';
   const sectionMap = {
-    description: {
-      title: 'description',
-      description: '',
-    },
+    description: '',
   };
   const lines = cleanStringArray(description.split('\r\n'));
 
   for (const line of lines) {
     if (line.includes('## ')) {
-      const sectionTitle = line.substring(3).trim().toLowerCase();
+      const sectionTitle = extractSectionTitle(line);
       const sectionKey = toCamelCase(sectionTitle);
-      sectionMap[sectionKey] = {
-        title: sectionTitle,
-        description: '',
-      };
+      sectionMap[sectionKey] = '';
       lastSectionKey = sectionKey;
     } else if (lastSectionKey) {
-      sectionMap[lastSectionKey].description += `${line}\n`;
+      sectionMap[lastSectionKey] += `${line}\n`;
     }
   }
 
   // clean data and extract url image
   Object.entries(sectionMap).forEach(([sectionKey, section]) => {
     if (!sectionKey.includes('screenshot')) {
-      return (section.description = section.description.trim());
+      return (section = section.trim());
     }
 
-    const match = section.description.match(/!\[.*?\]\((.*?)\)/);
-    section.description = match ? match[1] : null;
+    const match = section.match(/!\[.*?\]\((.*?)\)/);
+    section = match ? match[1] : null;
   });
 
   return sectionMap;
@@ -128,11 +131,11 @@ function extractPRMetadata(description = '') {
 function generateOverview(prRestMetadata) {
   const prMetadataKeys = Object.keys(prRestMetadata);
   const prOverview = prMetadataKeys.reduce((overview, metadataKey, index) => {
-    if (!prRestMetadata[metadataKey].description) {
+    if (!prRestMetadata[metadataKey]) {
       return overview;
     }
 
-    return `${overview}## ${capitalizeText(prRestMetadata[metadataKey].title)}\n${prRestMetadata[metadataKey].description}${prMetadataKeys.length - 1 === index ? '' : '\n'}`;
+    return `${overview}## ${camelCaseToNormal(metadataKey)}\n${prRestMetadata[metadataKey]}${prMetadataKeys.length - 1 === index ? '' : '\n'}`;
   }, '');
 
   return prOverview;
@@ -148,7 +151,7 @@ function formatPullRequestMessage(pullData, prMessageMeta) {
     prUrl: prMessageMeta.url,
     requester: prMessageMeta?.author?.name,
     title: pullRequestTitle,
-    howToTest: howToTest?.description || '',
+    howToTest: howToTest || '',
     overview: prOverview,
   });
 }

--- a/src/events/listenPullRequestOpenMessage.js
+++ b/src/events/listenPullRequestOpenMessage.js
@@ -89,8 +89,13 @@ function extractPRMetadata(description = '') {
     return {};
   }
 
-  let lastSectionKey = null;
-  const sectionMap = {};
+  let lastSectionKey = 'description';
+  const sectionMap = {
+    description: {
+      title: 'description',
+      description: '',
+    },
+  };
   const lines = cleanStringArray(description.split('\r\n'));
 
   for (const line of lines) {
@@ -123,6 +128,10 @@ function extractPRMetadata(description = '') {
 function generateOverview(prRestMetadata) {
   const prMetadataKeys = Object.keys(prRestMetadata);
   const prOverview = prMetadataKeys.reduce((overview, metadataKey, index) => {
+    if (!prRestMetadata[metadataKey].description) {
+      return overview;
+    }
+
     return `${overview}## ${capitalizeText(prRestMetadata[metadataKey].title)}\n${prRestMetadata[metadataKey].description}${prMetadataKeys.length - 1 === index ? '' : '\n'}`;
   }, '');
 


### PR DESCRIPTION
### Description
Added a default section to avoid send empty descriptions in discord channel with bot.

### Type of change

- [x] fix feature (non-breaking change which fix functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] Run project without errors.
 - [x] Run new command without errors.
 - [x] New feature is working fine 

### How to test
1. Run the project
2. Do the right configs to connect Github with discord
3. Make a PR
4. Check the bot response
