### PR TITLE
feat: open thread when a new pr is published

### DIFF
--- a/src/events/listenPullRequestOpenMessage.js
+++ b/src/events/listenPullRequestOpenMessage.js
@@ -194,7 +194,9 @@ module.exports = {
       );
 
       const prMessage = await channel.send(formattedMessage);
-      prMessage.startThread({ name: pullData.head.ref || 'template title' });
+      prMessage.startThread({
+        name: pullData.head.ref || `New PR-${pullData.number}`,
+      });
     } catch (error) {
       await handleError(error, message);
     }

--- a/src/events/listenPullRequestOpenMessage.js
+++ b/src/events/listenPullRequestOpenMessage.js
@@ -144,6 +144,21 @@ function formatPullRequestMessage(pullData, prMessageMeta) {
   });
 }
 
+async function startPRThread(client, pullData, formattedMessage) {
+  const channel = await client.channels.fetch(
+    GITHUB_PUBLISH_OPENED_PR.githubPRReviewChannel
+  );
+  const prMessage = await channel.send(formattedMessage);
+
+  prMessage.startThread({
+    name:
+      pullData.head.ref ||
+      translateLanguage('pullRequestOpen.newPrThreadName', {
+        pullNumber: pullData.number,
+      }),
+  });
+}
+
 async function handleError(error, message) {
   console.error('Error processing the PR:', error);
   saveErrorLog(error);
@@ -189,14 +204,7 @@ module.exports = {
         pullRequestMeta
       );
 
-      const channel = await client.channels.fetch(
-        GITHUB_PUBLISH_OPENED_PR.githubPRReviewChannel
-      );
-
-      const prMessage = await channel.send(formattedMessage);
-      prMessage.startThread({
-        name: pullData.head.ref || `New PR-${pullData.number}`,
-      });
+      await startPRThread(client, pullData, formattedMessage);
     } catch (error) {
       await handleError(error, message);
     }

--- a/src/events/listenPullRequestOpenMessage.js
+++ b/src/events/listenPullRequestOpenMessage.js
@@ -193,7 +193,8 @@ module.exports = {
         GITHUB_PUBLISH_OPENED_PR.githubPRReviewChannel
       );
 
-      await channel.send(formattedMessage);
+      const prMessage = await channel.send(formattedMessage);
+      prMessage.startThread({ name: pullData.head.ref || 'template title' });
     } catch (error) {
       await handleError(error, message);
     }

--- a/src/languages/translations/en-US.json
+++ b/src/languages/translations/en-US.json
@@ -226,7 +226,8 @@
   },
   "pullRequestOpen": {
     "errorExtractDataFromURL": "Error extracting repository or PR number from URL.",
-    "errorFetchPR": "Error trying to fetch PR data to {{prURL}}. URL: {{prURL}}. status: {{status}}"
+    "errorFetchPR": "Error trying to fetch PR data to {{prURL}}. URL: {{prURL}}. status: {{status}}",
+    "newPrThreadName": "New PR-{{pullNumber}}"
   },
   "assignTaskForum": {
     "description": "Assign the user tag to a task posted on the forum.",

--- a/src/languages/translations/es-ES.json
+++ b/src/languages/translations/es-ES.json
@@ -227,7 +227,8 @@
   },
   "pullRequestOpen": {
     "errorExtractDataFromURL": "Error al extraer el nombre del repositorio o el número de PR de la URL.",
-    "errorFetchPR": "Error al intentar obtener datos del PR. URL: {{prURL}}. Estado: {{status}}"
+    "errorFetchPR": "Error al intentar obtener datos del PR. URL: {{prURL}}. Estado: {{status}}",
+    "newPrThreadName": "Nuevo PR-{{pullNumber}}"
   },
   "assignTaskForum": {
     "description": "Asigna la etiqueta de usuario a una tarea publicada en el foro.",


### PR DESCRIPTION
### Description
Automatically create Discord thread for new PRs published. This PR addresses the need for manual Discord thread creation for each new pull request. It implements an automated process to create a thread with the branch name as its title in the designated channel. The thread will be automatically set to the 'Request Review' status. This enhancement simplifies the workflow, ensuring a dedicated discussion space for each review request right from the start.

### Type of change

- [x] new feature (non-breaking change which add functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] Run project without errors.
 - [x] Run commands without errors.
 - [x] New feature is working fine 

### How to test
1. Run the project
2. Do the right configs to connect Github with discord
3. Make a PR
4. Check the bot response

### Screenshots
>![image](https://github.com/user-attachments/assets/a3cd0d57-0902-4308-a03a-933181a7337f)

